### PR TITLE
feat: Read host/port/user/pass from env if set

### DIFF
--- a/deluge_reannounce.py
+++ b/deluge_reannounce.py
@@ -3,6 +3,7 @@
 # pip install deluge-client
 
 from __future__ import print_function
+import os
 import sys
 import time
 from deluge_client import DelugeRPCClient
@@ -13,10 +14,10 @@ torrent_name = sys.argv[2]
 torrent_path = sys.argv[3]
 
 # Set up Deluge RPC client connection details
-ip = "127.0.0.1"
-port = 11111  # Change this to your Deluge daemon port
-username = "str0ke"  # Change this to your Deluge username
-password = "password"  # Change this to your Deluge password
+ip = os.getenv('DELUGE_HOST', "127.0.0.1")
+port = int(os.getenv('DELUGE_PORT', 58846))
+username = os.getenv('DELUGE_USER', 'admin')
+password = os.getenv('DELUGE_PASS', 'deluge')
 
 # Set up loop parameters
 max_iterations = 120


### PR DESCRIPTION
This enables them to be passed from a calling script without committing your password to Git.  For instance, here is my script for running inside the linuxserver/deluge container:
```
#!/bin/bash

cd `dirname $0`

if [ -r /config/auth ]; then
    # take the user/pass from the last admin-level in the file
    export DELUGE_USER=$(tac /config/auth | awk -F: '$3=="10" {print $1; exit}')
    export DELUGE_PASS=$(tac /config/auth | awk -F: '$3=="10" {print $2; exit}')
fi
if [ -r /config/core.conf ]; then
    export DELUGE_HOST='127.0.0.1'
    export DELUGE_PORT=$(cat /config/core.conf | jq -s '.[1].daemon_port')
fi

python deluge_reannounce.py "$@" >>reannounce.log 2>&1
```